### PR TITLE
Allow user to choose Blackboard URL

### DIFF
--- a/Chrome/html/options.html
+++ b/Chrome/html/options.html
@@ -6,14 +6,21 @@
 	</head>
 	<body>
 		<div id="wrapper">
-			Default Forum View:
-			<select id="forum_view">
-				<option value="tree">Tree</option>
-				<option value="list">List</option>
-			</select>
+			<div>
+				Default Forum View:
+				<select id="forum_view">
+					<option value="tree">Tree</option>
+					<option value="list">List</option>
+				</select>
+			</div>
+			<div>
+				Domain of blackboard site:
+				<input type="text" id="blackboard_domain" placeholder="e.g., bb.uis.edu">
+			</div>
 			<div id="status"></div>
 			<button id="save">Save</button>
 			<script src="../scripts/values.js"></script>
+			<script src="../scripts/utility.js"></script>
 			<script src="../scripts/options.js"></script>
 		</div>
 	</body>

--- a/Chrome/html/options.html
+++ b/Chrome/html/options.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="UTF-8">
 		<title>BlackboardEnhancementSuite Options</title>
 		<link rel="stylesheet" type="text/css" href="../css/options.css">
 	</head>

--- a/Chrome/html/options.html
+++ b/Chrome/html/options.html
@@ -14,8 +14,8 @@
 				</select>
 			</div>
 			<div>
-				Domain of blackboard site:
-				<input type="text" id="blackboard_domain" placeholder="e.g., bb.uis.edu">
+				Domains of blackboard sites (one line for each):
+				<textarea id="blackboard_domains" placeholder="e.g., bb.uis.edu"></textarea
 			</div>
 			<div id="status"></div>
 			<button id="save">Save</button>

--- a/Chrome/html/welcome.html
+++ b/Chrome/html/welcome.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Welcome to Blackboard Enhancement Suite</title>
+		<link rel="stylesheet" type="text/css" href="../css/options.css">
+	</head>
+	<body>
+		<div id="wrapper">
+			<h2>Welcome to Blackboard Enhancment Suite</h2>
+			<p>To get started, please enter your blackboard website into the <a href="options.html">options page</a>. Thank you! We hope you enjoy this extension.</p>
+		</div>
+	</body>
+</html>

--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -13,23 +13,12 @@
 		"48": "images/icon-48.png",
 		"128": "images/icon-128.png"
 	},
-	"content_scripts": [
-		{
-			"matches": [
-				"http://*.edu/*",
-				"https://*.edu/*"
-			],
-			"include_globs": [
-				"https://bb.*.edu/*",
-				"http://bb.*.edu/*",
-				"https://blackboard.*.edu/*",
-				"http://blackboard.*.edu/*"
-			],
-			"js": [ "scripts/enhance.js" ],
-			"run_at": "document_end"
-		}
-	],
 	"options_page": "html/options.html",
+	"optional_permissions": [
+	  "tabs",
+	  "http://*.edu/*",
+	  "https://*.edu/*"
+	],
 	"background": {
 		"page": "html/background.html",
 		"persistent": false

--- a/Chrome/scripts/background.js
+++ b/Chrome/scripts/background.js
@@ -9,3 +9,17 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 		return true;
 	}
 });
+
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+	chrome.storage.sync.get(bb_values.default_options, function(items) {
+		if (items.blackboard_domain != bb_values.default_options.blackboard_domain
+		    && changeInfo.status == "complete") {
+			chrome.permissions.contains({
+				permissions: ['tabs'],
+				origins: [tab.url]
+			}, function(does) {
+				if (does) chrome.tabs.executeScript(tabId, {file: "scripts/enhance.js"});
+			});
+		}
+	});
+});

--- a/Chrome/scripts/background.js
+++ b/Chrome/scripts/background.js
@@ -11,15 +11,13 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 });
 
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+	if (!("url" in tab)) return; // probably no "tabs" permissions for page loaded
+	var pageDomain = tab.url.match(/:\/\/([^\/]+)/)[1];
 	chrome.storage.sync.get(bb_values.default_options, function(items) {
-		if (items.blackboard_domain != bb_values.default_options.blackboard_domain
-		    && changeInfo.status == "complete") {
-			chrome.permissions.contains({
-				permissions: ['tabs'],
-				origins: [tab.url]
-			}, function(does) {
-				if (does) chrome.tabs.executeScript(tabId, {file: "scripts/enhance.js"});
-			});
+		if (items.blackboard_domains !== bb_values.default_options.blackboard_domains
+		    && changeInfo.status == "complete"
+		    && items.blackboard_domains.includes(pageDomain)) {
+			chrome.tabs.executeScript(tabId, {file: "scripts/enhance.js"});
 		}
 	});
 });

--- a/Chrome/scripts/background.js
+++ b/Chrome/scripts/background.js
@@ -10,6 +10,14 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 	}
 });
 
+// Show welcome page on installation
+chrome.runtime.onInstalled.addListener(function() {
+	chrome.tabs.create({
+		url: chrome.runtime.getURL("html/welcome.html")
+	});
+});
+
+// Inject content script as appropriate.  Needed since content script globs aren't flexible enough
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
 	if (!("url" in tab)) return; // probably no "tabs" permissions for page loaded
 	var pageDomain = tab.url.match(/:\/\/([^\/]+)/)[1];

--- a/Chrome/scripts/options.js
+++ b/Chrome/scripts/options.js
@@ -15,20 +15,21 @@ function save_options() {
 		data.errors = [];
 		nextOperation();
 	}).operation(function(nextOperation, data) {
-		var blackboard_domain = document.getElementById("blackboard_domain").value;
+		var blackboard_domains = document.getElementById("blackboard_domains").value.split("\n");
+		var origins = blackboard_domains.map((x) => [
+			           "https://" + x + "/",
+			           "http://" + x + "/"
+			         ]).reduce((a,b) => a.concat(b));
+		console.log(origins);
 		chrome.permissions.request({
-			permissions: ['tabs'],
-			origins: ["https://" + blackboard_domain + "/",
-			          "http://" + blackboard_domain + "/"]
+			permissions: ["tabs"],
+			origins: origins
 		}, function(granted) {
-			chrome.permissions.getAll(function(permissions) {
-				console.log(permissions);
-			});
 			if (chrome.runtime.lastError) {
 				data.errors.push(chrome.runtime.lastError.message);
 			}
 			if (granted) {
-				data.sync.blackboard_domain = blackboard_domain;
+				data.sync.blackboard_domains = blackboard_domains;
 			}
 			nextOperation();
 		});
@@ -53,7 +54,7 @@ function restore_options() {
 	// get options, or return default values if not set
 	chrome.storage.sync.get(bb_values.default_options, function (items) {
 		document.getElementById("forum_view").value = items.forum_view;
-		document.getElementById("blackboard_domain").value = items.blackboard_domain;
+		document.getElementById("blackboard_domains").value = items.blackboard_domains.join("\n");
 	});
 }
 

--- a/Chrome/scripts/options.js
+++ b/Chrome/scripts/options.js
@@ -1,18 +1,50 @@
 // Based on https://developer.chrome.com/extensions/options
 
+function show_status(text, interval) {
+	var statusEl = document.getElementById("status");
+	statusEl.textContent += text;
+	setTimeout(function() {
+		statusEl.textContent = "";
+	}, interval || 1000);
+}
+
 // Save options
 function save_options() {
-	var forum_view = document.getElementById("forum_view").value;
-	chrome.storage.sync.set({
-		forum_view: forum_view,
-	}, function() {
-		// Update status to let the user know options were saved
-		var status = document.getElementById("status");
-		status.textContent = "Options Saved";
-		setTimeout(function() {
-			status.textContent = "";
-		}, 750);
-	});
+	new OperationList().operation((nextOperation,data) => {
+		data.sync = {};
+		data.errors = [];
+		nextOperation();
+	}).operation(function(nextOperation, data) {
+		var blackboard_domain = document.getElementById("blackboard_domain").value;
+		chrome.permissions.request({
+			permissions: ['tabs'],
+			origins: ["https://" + blackboard_domain + "/",
+			          "http://" + blackboard_domain + "/"]
+		}, function(granted) {
+			chrome.permissions.getAll(function(permissions) {
+				console.log(permissions);
+			});
+			if (chrome.runtime.lastError) {
+				data.errors.push(chrome.runtime.lastError.message);
+			}
+			if (granted) {
+				data.sync.blackboard_domain = blackboard_domain;
+			}
+			nextOperation();
+		});
+	}).operation(function(nextOperation, data) {
+		data.sync.forum_view = document.getElementById("forum_view").value;
+		nextOperation();
+	}).operation(function(nextOperation, data) {
+		if (data.errors.length) {
+			show_status(data.errors.join("\n"), 2000);
+		} else {
+			chrome.storage.sync.set(data.sync, function() {
+				// Update status to let the user know options were saved
+				show_status("Options Saved");
+			});
+		}
+	}).performInSequence();
 }
 
 
@@ -21,6 +53,7 @@ function restore_options() {
 	// get options, or return default values if not set
 	chrome.storage.sync.get(bb_values.default_options, function (items) {
 		document.getElementById("forum_view").value = items.forum_view;
+		document.getElementById("blackboard_domain").value = items.blackboard_domain;
 	});
 }
 

--- a/Chrome/scripts/utility.js
+++ b/Chrome/scripts/utility.js
@@ -1,0 +1,48 @@
+// Utility functions and classes to make life easier
+
+/**
+ * Class to make it easy to perform a series of functions
+ * in order, after waiting for their callbacks to be called
+ *
+ * @class
+ */
+function OperationList() {
+  this.funcs = [];
+  this.data = {};
+}
+
+/**
+ * This callback defines the steps and completion of an
+ * operation.
+ * @callback OperationList~operationCallback
+ * @param {function} next - zero-argument function that
+ *        can be called to go to the next operation in
+ *        the list.
+ * @param {object} data - an object stored in OperationList
+ *        that operations can all share.
+ */
+
+/**
+ * This method allows operations to be added in the "chaining"
+ * style (i.e., opList.operation(...).operation(...)).
+ *
+ * @param {operationCallback} func - what the operation does
+ * @return {OperationList} the original operation list class
+ */
+OperationList.prototype.operation = function(func) {
+  this.funcs.push(func);
+  return this;
+}
+
+/**
+ * This method indicates that all operations have been added
+ * so they can start being performed.
+ */
+OperationList.prototype.performInSequence = function() {
+  var self = this;
+  if (self.funcs.length > 0) {
+    self.funcs.splice(0,1)[0](() => {
+      self.performInSequence();
+    }, self.data);
+  }
+}

--- a/Chrome/scripts/values.js
+++ b/Chrome/scripts/values.js
@@ -1,6 +1,6 @@
 var bb_values = {
 	"default_options": {
 		"forum_view": "list",
-		"blackboard_domain": ""
+		"blackboard_domains": []
 	}
 };

--- a/Chrome/scripts/values.js
+++ b/Chrome/scripts/values.js
@@ -1,5 +1,6 @@
 var bb_values = {
 	"default_options": {
-		"forum_view": "list"
+		"forum_view": "list",
+		"blackboard_domain": ""
 	}
 };


### PR DESCRIPTION
Since bb.\*.edu and blackboard.\*.edu doesn't seem to include every blackboard installation, as #6  seems to show, it seems to me we have three choices:

1. Keep broadening the scope of the content script match patterns (i.e., now we could make it match *.edu).  This seems like it could be undesirable for users, especially if someone's Blackboard site is at *.com.
2. Maintain a list of patterns or URLs for Blackboard websites.  (i.e., bb.*.edu, *.blackboard.com, and so on)
3. Allow the user to choose the domain(s) of their blackboard installation.

Here I've implemented option 3.  Let me know what you think.  The user enters the domain in the options page, and there's a "welcome page" when the extension is installed, that directs them to the options page for initial setup.

I'd be happy to change it around if you think something else would be better.

Thanks!